### PR TITLE
Fix require statement in bin/ical-view

### DIFF
--- a/bin/ical-view
+++ b/bin/ical-view
@@ -1,5 +1,5 @@
 #!/usr/bin/env ruby
 
-require 'ical-viewer'
+require 'ical-view'
 
 ICalViewer.run ARGV


### PR DESCRIPTION
This package is called ical-view, not ical-viewer, so requiring
'ical-viewer' in bin/ical-view will fail.