### PR TITLE
fix Icalendar.parse depreation warning

### DIFF
--- a/lib/ical-view.rb
+++ b/lib/ical-view.rb
@@ -96,7 +96,7 @@ module ICalViewer
 
       u.dbg "Parsing #{file}"
       begin
-        cals  = Icalendar.parse f
+        cals  = Icalendar::Calendar.parse f
       rescue ArgumentError => e
         u.err "Cannot parse #{file}"
         u.err e.to_s


### PR DESCRIPTION
use Icalendar::Calendar.parse instead